### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2024-11-02
+
+- Added the *ObservableUpdateFlag* to help performance when updating subscribers to the *ObservableDictionary*. By default is set *ObservableUpdateFlag.KeyUpdateOnly*
+
+**Fix**:
+- Fixed an issue that would no setup Remove update action to Subscribers when calling *Clear* on the *ObservableDictionary*
+
 ## [0.6.1] - 2024-11-01
 
 **Fix**:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.gamelovers.dataextensions",
   "displayName": "Unity Data Type Extensions",
   "author": "Miguel Tomas",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "unity": "2022.3",
   "license": "MIT",
   "description": "This package extends various sets of data types to be used in any type of data containers or persistent serializable data",


### PR DESCRIPTION
- Added the *ObservableUpdateFlag* to help performance when updating subscribers to the *ObservableDictionary*. By default is set *ObservableUpdateFlag.KeyUpdateOnly*

**Fix**:
- Fixed an issue that would no setup Remove update action to Subscribers when calling *Clear* on the *ObservableDictionary*
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduces the `ObservableUpdateFlag` enum to control update behavior in `ObservableDictionary`, improving performance when updating subscribers.
- Bug Fix: Resolves an issue with setting the Remove update action on `Clear` in `ObservableDictionary`.
- Documentation: Updates the CHANGELOG.md file to reflect the changes made to `ObservableDictionary` and provide a summary of the improvements.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `ObservableUpdateFlag` to enhance performance for updating subscribers in the `ObservableDictionary`.
- **Bug Fixes**
	- Resolved an issue where the `Remove` update action was not set for subscribers when the `Clear` method was called.
- **Documentation**
	- Updated changelog to reflect new version 0.6.2 and summarize recent changes and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->