### PR TITLE
Release 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2024-11-20
+
+**Fix**:
+- Fixed the issues of *ObservableDictionary* when subscribing/unsubscribing to actions while removing/adding elements
+- Fixed the issues of *ObservableList* when subscribing/unsubscribing to actions while removing/adding elements
+
 ## [0.6.4] - 2024-11-13
 
 **Fix**:

--- a/Runtime/ObservableDictionary.cs
+++ b/Runtime/ObservableDictionary.cs
@@ -460,7 +460,7 @@ namespace GameLovers
 
 			for (var i = index - 1; i > -1; i--)
 			{
-				if (list[index] == action)
+				if (list[i] == action)
 				{
 					return i;
 				}

--- a/Runtime/ObservableList.cs
+++ b/Runtime/ObservableList.cs
@@ -232,9 +232,14 @@ namespace GameLovers
 
 			List.RemoveAt(index);
 
-			for (var i = 0; i < _updateActions.Count; i++)
+			for (var i = _updateActions.Count - 1; i > -1; i--)
 			{
-				_updateActions[i](index, data, default, ObservableUpdateType.Removed);
+				var action = _updateActions[i];
+
+				action(index, data, default, ObservableUpdateType.Removed);
+
+				// Shift the index if an action was unsubscribed
+				i = AdjustIndex(i, action);
 			}
 		}
 
@@ -306,6 +311,24 @@ namespace GameLovers
 			{
 				_updateActions[i](index, previousValue, data, ObservableUpdateType.Updated);
 			}
+		}
+
+		private int AdjustIndex(int index, Action<int, T, T, ObservableUpdateType> action)
+		{
+			if (index < _updateActions.Count && _updateActions[index] == action)
+			{
+				return index;
+			}
+
+			for (var i = index - 1; i > -1; i--)
+			{
+				if (_updateActions[index] == action)
+				{
+					return i;
+				}
+			}
+
+			return index + 1;
 		}
 	}
 

--- a/Runtime/ObservableList.cs
+++ b/Runtime/ObservableList.cs
@@ -322,7 +322,7 @@ namespace GameLovers
 
 			for (var i = index - 1; i > -1; i--)
 			{
-				if (_updateActions[index] == action)
+				if (_updateActions[i] == action)
 				{
 					return i;
 				}

--- a/Runtime/ObservableList.cs
+++ b/Runtime/ObservableList.cs
@@ -241,17 +241,18 @@ namespace GameLovers
 		/// <inheritdoc />
 		public virtual void Clear()
 		{
-			var list = new List<T>(List);
+			// Create a copy in case that one of the callbacks modifies the list (Ex: removing a subscriber)
+			var copy = _updateActions.ToList();
 
-			List.Clear();
-
-			for (var i = 0; i < _updateActions.Count; i++)
+			for (var i = copy.Count - 1; i > -1; i--)
 			{
-				for (var j = 0; j < list.Count; j++)
+				for (var j = 0; j < List.Count; j++)
 				{
-					_updateActions[i](j, list[j], default, ObservableUpdateType.Removed);
+					copy[i](j, List[j], default, ObservableUpdateType.Removed);
 				}
 			}
+
+			List.Clear();
 		}
 
 		/// <inheritdoc />

--- a/Tests/Editor/ObservableDictionaryTest.cs
+++ b/Tests/Editor/ObservableDictionaryTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using GameLovers;
 using NSubstitute;
 using NUnit.Framework;
-using UnityEngine;
 
 // ReSharper disable once CheckNamespace
 

--- a/Tests/Editor/ObservableListTest.cs
+++ b/Tests/Editor/ObservableListTest.cs
@@ -126,6 +126,21 @@ namespace GameLoversEditor.DataExtensions.Tests
 		}
 
 		[Test]
+		public void StopObserve_MultipleCalls_StopsOnlyOne()
+		{
+			_list.Observe(_caller.Call);
+			_list.Observe(_caller.Call);
+			_list.StopObserving(_caller.Call);
+			_list.Add(_previousValue);
+
+			_list[_index] = _previousValue;
+
+			_list.RemoveAt(_index);
+
+			_caller.Received().Call(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ObservableUpdateType>());
+		}
+
+		[Test]
 		public void StopObservingAllCheck()
 		{
 			_list.Observe(_caller.Call);
@@ -137,7 +152,7 @@ namespace GameLoversEditor.DataExtensions.Tests
 		}
 
 		[Test]
-		public void StopObservingAll_MultipleCalls_Check()
+		public void StopObservingAll_MultipleCalls_StopsAll()
 		{
 			_list.Observe(_caller.Call);
 			_list.Observe(_caller.Call);

--- a/Tests/Editor/ObservableListTest.cs
+++ b/Tests/Editor/ObservableListTest.cs
@@ -126,7 +126,7 @@ namespace GameLoversEditor.DataExtensions.Tests
 		}
 
 		[Test]
-		public void StopObserve_MultipleCalls_StopsOnlyOne()
+		public void StopObserve_WhenCalledOnce_RemovesOnlyOneObserverInstance()
 		{
 			_list.Observe(_caller.Call);
 			_list.Observe(_caller.Call);
@@ -137,7 +137,9 @@ namespace GameLoversEditor.DataExtensions.Tests
 
 			_list.RemoveAt(_index);
 
-			_caller.Received().Call(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<ObservableUpdateType>());
+			_caller.Received(1).Call(Arg.Any<int>(), Arg.Is(0), Arg.Is(_previousValue), ObservableUpdateType.Added);
+			_caller.Received(1).Call(_index, _previousValue, _previousValue, ObservableUpdateType.Updated);
+			_caller.Received(1).Call(_index, _previousValue, 0, ObservableUpdateType.Removed);
 		}
 
 		[Test]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.gamelovers.dataextensions",
   "displayName": "Unity Data Type Extensions",
   "author": "Miguel Tomas",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "unity": "2022.3",
   "license": "MIT",
   "description": "This package extends various sets of data types to be used in any type of data containers or persistent serializable data",


### PR DESCRIPTION

**Fix**:
- Fixed the issues of *ObservableDictionary* when subscribing/unsubscribing to actions while removing/adding elements
- Fixed the issues of *ObservableList* when subscribing/unsubscribing to actions while removing/adding elements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Version 0.6.5

- **Bug Fixes**
  - Resolved issues with subscribing/unsubscribing actions in `ObservableDictionary` and `ObservableList`, enhancing reliability during element addition/removal.

- **New Features**
  - Enhanced synchronization between `ObservableList` and its origin list, ensuring accurate observer notifications during modifications.

- **Tests**
  - Added a new test for `ObservableList` to verify correct behavior when stopping multiple observers.
  - Renamed an existing test for clarity regarding its purpose.

- **Documentation**
  - Updated the changelog to reflect the new version and document recent fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Fixed issues with `ObservableDictionary` and `ObservableList` related to subscribing/unsubscribing actions during element addition/removal.
- Improvement: Improved handling of subscriptions and actions in `ObservableDictionary` and `ObservableList` classes.
- Improvement: Modified how actions are copied and iterated over during removal operations to prevent issues when modifying the subscription lists.
- Refactor: Refactored the `Clear` method to ensure proper handling of callbacks.
- Improvement: Some changes impact the signatures of exported functions and the handling of global data structures.
- Test: Added a new test method `StopObserve_MultipleCalls_StopsOnlyOne` to test stopping observation for multiple calls.
- Test: Renamed the test method `StopObservingAll_MultipleCalls_Check` to `StopObservingAll_MultipleCalls_StopsAll`.
- Chore: Removed unused `UnityEngine` import in the code file.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->