### PR TITLE
Release 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.6] - 2024-11-30
+
+**Fix**:
+- *ObservableDictionary.Remove(T)* no longer sends an update if id doesn't find the element to remove it
+
 ## [0.6.5] - 2024-11-20
 
 **Fix**:

--- a/Runtime/ObservableDictionary.cs
+++ b/Runtime/ObservableDictionary.cs
@@ -266,12 +266,10 @@ namespace GameLovers
 		/// <inheritdoc />
 		public virtual bool Remove(TKey key)
 		{
-			if (!Dictionary.TryGetValue(key, out var value))
+			if (!Dictionary.TryGetValue(key, out var value) || !Dictionary.Remove(key))
 			{
 				return false;
 			}
-
-			Dictionary.Remove(key);
 
 			if (ObservableUpdateFlag != ObservableUpdateFlag.UpdateOnly && _keyUpdateActions.TryGetValue(key, out var actions))
 			{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.gamelovers.dataextensions",
   "displayName": "Unity Data Type Extensions",
   "author": "Miguel Tomas",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "unity": "2022.3",
   "license": "MIT",
   "description": "This package extends various sets of data types to be used in any type of data containers or persistent serializable data",


### PR DESCRIPTION
**Fix**:
- *ObservableDictionary.Remove(T)* no longer sends an update if id doesn't find the element to remove it
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Fixed an issue in version 0.6.6 where `ObservableDictionary.Remove(T)` would trigger an unnecessary update when the element to remove was not found. The code change now correctly checks if the key exists before attempting to remove it, preventing unnecessary updates when the key is not found.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `Remove` method in the `ObservableDictionary` to prevent unnecessary notifications when an element to remove is not found.
	- Enhanced the `Clear` method to ensure all keys are cleared and updates are invoked correctly.

- **Chores**
	- Updated the version number to 0.6.6 in the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->